### PR TITLE
Pin GMT to 6.5.0 in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,11 @@
 name: gmt-examples
 channels:
-    - conda-forge
-    - defaults
+  - conda-forge
+  - nodefaults
 dependencies:
-    - gmt
-    - myst-parser
-    - sphinx
-    - sphinx_gmt
-    - sphinx_rtd_theme
+  - python=3.12
+  - gmt=6.5.0
+  - myst-parser
+  - sphinx
+  - sphinx_gmt
+  - sphinx_rtd_theme


### PR DESCRIPTION
New GMT versions may break examples in an unexpected way (bugs!), so better to pin GMT
to a specific version so that we can check the examples when bumping to new GMT versions.
