### PR TITLE
Remove CODE_OF_CONDUCT.md and use the organization-wide CODE OF CONDUCT file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,2 +1,0 @@
-All participants in the PyGMT community must abide by
-the [Generic Mapping Tools organization Code of Conduct](https://github.com/GenericMappingTools/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,8 @@ in the [contributors guide](https://www.generic-mapping-tools.org/gmt-examples/c
 
 The goal is to maintain a diverse community that's pleasant for everyone.
 **Please be considerate and respectful of others**.
-Everyone must abide by our [Code of Conduct](CODE_OF_CONDUCT.md) and we encourage all to
-read it carefully.
+Everyone must abide by our [Code of Conduct](https://github.com/GenericMappingTools/.github/blob/main/CODE_OF_CONDUCT.md)
+and we encourage all to read it carefully.
 
 ## The `AUTHORS.md` file
 


### PR DESCRIPTION
See https://github.com/GenericMappingTools/pygmt/pull/3285 for context.

This PR remove the local `CODE_OF_CONDUCT.md` file.